### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/mainf/query.py
+++ b/mainf/query.py
@@ -44,10 +44,10 @@ elif search.lower() == 'ttd':
 # Minecraft wiki (also dis)
 
 elif search.lower() == 'minecraft':
-    os.system('browsh https://minecraft.fandom.com/wiki/Minecraft_Wiki')
+    os.system('browsh https://minecraft.wiki/w/Minecraft_Wiki')
 
 elif search.lower() == 'mc':
-    os.system('browsh https://minecraft.fandom.com/wiki/Minecraft_Wiki')
+    os.system('browsh https://minecraft.wiki/w/Minecraft_Wiki')
 
 # exit software
 

--- a/slack/query.py
+++ b/slack/query.py
@@ -131,10 +131,10 @@ os.system("browsh https://wiki.openttd.org/en/")
 # Minecraft wiki (also dis)
 
 elif search.lower() == 'minecraft':
-os.system('browsh https://minecraft.fandom.com/wiki/Minecraft_Wiki')
+os.system('browsh https://minecraft.wiki/w/Minecraft_Wiki')
 
 elif search.lower() == 'mc':
-os.system('browsh https://minecraft.fandom.com/wiki/Minecraft_Wiki')
+os.system('browsh https://minecraft.wiki/w/Minecraft_Wiki')
 
 # exit software
 

--- a/termux/termweb.py
+++ b/termux/termweb.py
@@ -129,10 +129,10 @@ def query():
 # Minecraft wiki (also dis)
 
     elif search.lower() == 'minecraft':
-        os.system('lynx https://minecraft.fandom.com/wiki/Minecraft_Wiki')
+        os.system('lynx https://minecraft.wiki/w/Minecraft_Wiki')
 
     elif search.lower() == 'mc':
-        os.system('lynx https://minecraft.fandom.com/wiki/Minecraft_Wiki')
+        os.system('lynx https://minecraft.wiki/w/Minecraft_Wiki')
 
 # exit software
     elif search.lower() == "exit":

--- a/voidgirls/query.py
+++ b/voidgirls/query.py
@@ -131,10 +131,10 @@ def query():
     # Minecraft wiki (also dis)
 
     elif search.lower() == 'minecraft':
-        os.system('lynx https://minecraft.fandom.com/wiki/Minecraft_Wiki')
+        os.system('lynx https://minecraft.wiki/w/Minecraft_Wiki')
 
     elif search.lower() == 'mc':
-        os.system('lynx https://minecraft.fandom.com/wiki/Minecraft_Wiki')
+        os.system('lynx https://minecraft.wiki/w/Minecraft_Wiki')
 
     # exit software
 

--- a/voidgirls/voidweb.py
+++ b/voidgirls/voidweb.py
@@ -131,10 +131,10 @@ def query():
     # Minecraft wiki (also dis)
 
     elif search.lower() == 'minecraft':
-        os.system('lynx https://minecraft.fandom.com/wiki/Minecraft_Wiki')
+        os.system('lynx https://minecraft.wiki/w/Minecraft_Wiki')
 
     elif search.lower() == 'mc':
-        os.system('lynx https://minecraft.fandom.com/wiki/Minecraft_Wiki')
+        os.system('lynx https://minecraft.wiki/w/Minecraft_Wiki')
 
     # exit software
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki